### PR TITLE
The GUI now outputs an error message on Windows for Unix-only operations

### DIFF
--- a/apt_offline_gui/AptOfflineQtMain.py
+++ b/apt_offline_gui/AptOfflineQtMain.py
@@ -73,8 +73,12 @@ class AptOfflineQtMain(QtGui.QMainWindow):
         
     
     def CreateProfile(self):
-        if os.geteuid() != 0:
-                QtGui.QMessageBox.critical(self, "Error", "You need to run with root priviliges")
+        try:
+                if os.geteuid() != 0:
+                        QtGui.QMessageBox.critical(self, "Error", "You need to run with root privileges!")
+                        return
+        except AttributeError:
+                QtGui.QMessageBox.critical(self, "Error", "This is supported only on Unix like systems with apt installed.")
                 return
         # Code for creating Modal Dialog for Create Profile
         self.createProfileDialog.resetUI()
@@ -86,9 +90,13 @@ class AptOfflineQtMain(QtGui.QMainWindow):
         self.createDownloadDialog.show()
 
     def InstallPackagesUpgrades(self):
-        #if os.geteuid() != 0:
-        #        QtGui.QMessageBox.critical(self, "Error", "You need to run with root priviliges")
-        #        return
+        try:
+                if os.geteuid() != 0:
+                        QtGui.QMessageBox.critical(self, "Error", "You need to run with root privileges!")
+                        return
+        except AttributeError:
+                QtGui.QMessageBox.critical(self, "Error", "This is supported only on Unix like systems with apt installed.")
+                return
         # Code for creating Modal Dialog for Installing Packages/Upgrades
         self.createInstallDialog.show()
     


### PR DESCRIPTION
Apt-offline checks if the `install` and `set` option can be used on the current system, when using the CLI version.

However, it only checks those two operations for Linux on the GUI.

So instead of getting the following error when using the GUI version on Windows:

```python
    if os.geteuid() != 0:
AttributeError: 'module' object has no attribute 'geteuid'
```

It now shows the error message:
> This is supported only on Unix like systems with apt installed.
