### PR TITLE
bash completion script for apt-offline

### DIFF
--- a/bash_completion/apt-offline
+++ b/bash_completion/apt-offline
@@ -1,0 +1,114 @@
+# Debian apt-offline(8) completion                             -*- shell-script -*-
+
+_apt_offline()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    local special i
+    for (( i=0; i < ${#words[@]}-1; i++ )); do
+        if [[ ${words[i]} == @(set|get|install|--install-packages|--install-src-packages) ]]; then
+            special=${words[i]}
+        fi
+    done
+
+    if [[ -n $special ]]; then
+        case $special in
+            --install-src-packages)
+                COMPREPLY=( $( apt-cache --no-generate pkgnames "$cur" \
+                    2> /dev/null ) $( apt-cache dumpavail | \
+                    command grep "^Source: $cur" | sort -u | cut -f2 -d" " ) )
+                return 0
+                ;;
+            --install-packages)
+                COMPREPLY=( $( apt-cache --no-generate pkgnames "$cur" \
+                    2> /dev/null ) )
+                return 0
+                ;;
+            get)
+                case $prev in
+                    -d|--download-dir|-s|--cache-dir)
+                        _filedir -d
+                        return 0
+                        ;;
+                    --bundle)
+                        _filedir
+                        return 0
+                        ;;
+                    --proxy-host)
+                        _ip_addresses
+                        return 0
+                        ;;
+                    --socket-timeout)
+                        COMPREPLY=( $( compgen -W '10 30 100 300 1000' -- "$cur" ) )
+                        return 0
+                        ;;
+                    -t|--threads)
+                        COMPREPLY=( $( compgen -W '2 3 4 5 6 7 8 9 10' -- "$cur" ) )
+                        return 0
+                        ;;
+                esac
+                if [[ "$cur" == -* || -e $prev ]]; then
+                    COMPREPLY=( $( compgen -W '-h --help -v --verbose --version
+                        --simulate --socket-timeout -d --download-dir -s
+                        --cache-dir --no-checksum -t --threads --bundle
+                        --bug-reports --proxy-host --proxy-port' -- "$cur" ) )
+                else
+                    _filedir
+                fi
+                return 0
+                ;;
+            install)
+                case $prev in
+                    --install-src-path)
+                        _filedir -d
+                        return 0
+                        ;;
+                esac
+                if [[ "$cur" == -* || -e $prev ]]; then
+                    COMPREPLY=( $( compgen -W '-h --help -v --verbose --version
+                        --simulate --install-src-path --skip-bug-reports
+                        --allow-unauthenticated' -- "$cur" ) )
+                else
+                    _filedir
+                fi
+                return 0
+                ;;
+            set)
+                case $prev in
+                    --release)
+                        COMPREPLY=( $( apt-cache policy | \
+                            command grep "release.o=Debian,a=$cur" | \
+                            sed -e "s/.*a=\(\w*\).*/\1/" | uniq 2> /dev/null) )
+                        return 0
+                        ;;
+                    --upgrade-type)
+                        COMPREPLY=( $( compgen -W 'upgrade dist-upgrade
+                            dselect-ugprade' -- "$cur" ) )
+                        return 0
+                        ;;
+                esac
+                if [[ "$cur" == -* || -e $prev ]]; then
+                    COMPREPLY=( $( compgen -W '-h --help -v --verbose --version
+                        --simulate --install-packages --install-src-packages
+                        --src-build-dep --release --update --upgrade
+                        --upgrade-type' -- "$cur" ) )
+                else
+                    _filedir
+                fi
+                return 0
+                ;;
+        esac
+    fi
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $( compgen -W '-h --help -v --verbose --version --simulate' -- "$cur" ) )
+    else
+        COMPREPLY=( $( compgen -W 'get install set' -- "$cur" ) )
+    fi
+
+    return 0
+} &&
+complete -F _apt_offline apt-offline
+
+# ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
This is modeled after the bash-completion script for apt-get.  It tries to
do everything as automatic as possible.  It presents suggested values of
options that accept a numeric value.
