### PR TITLE
add --basepath option for pointing to removeable storage path

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -2072,7 +2072,7 @@ def main():
         parser_set = subparsers.add_parser('set', parents=[global_options])
         parser_set.set_defaults(func=setter)
         
-        parser_set.add_argument('set',
+        parser_set.add_argument('set', nargs='?',
                           help="Generate a signature file",
                           action="store", type=str, metavar="apt-offline.sig",
                           default="apt-offline.sig")
@@ -2112,7 +2112,7 @@ def main():
         #INFO: When get option is called, call the fetcher() function
         parser_get.set_defaults(func=fetcher)
         
-        parser_get.add_argument('get',
+        parser_get.add_argument('get', nargs='?',
                           help="Get apt-offline data",
                           action="store", type=str, metavar="apt-offline.sig",
                           default="apt-offline.sig")
@@ -2122,7 +2122,8 @@ def main():
         
         parser_get.add_argument("-d", "--download-dir", dest="download_dir",
                           help="Folder path to save files to", action="store",
-                          type=str, metavar="apt-downloads")
+                          type=str, metavar="apt-downloads",
+                          default="apt-offline-download")
         
         parser_get.add_argument("-s", "--cache-dir", dest="cache_dir",
                           help="Cache folder to search for",
@@ -2151,9 +2152,10 @@ def main():
         parser_install = subparsers.add_parser('install', parents=[global_options])
         parser_install.set_defaults(func=installer)
         
-        parser_install.add_argument('install',
+        parser_install.add_argument('install', nargs='?',
                           help="Install apt-offline data, a bundle file or a directory",
-                          action="store", type=str, metavar="apt-offline-download.zip | apt-offline-download/")
+                          action="store", type=str, metavar="apt-offline-download.zip | apt-offline-download/",
+                          default="apt-offline-download")
 
         parser_install.add_argument("--install-src-path", dest="install_src_path",
                                     help="Install src packages to specified path.", default=None)

--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -872,8 +872,16 @@ def fetcher( args ):
         
         # get opts
         Str_GetArg = args.get
-        Int_SocketTimeout = args.socket_timeout
         Str_DownloadDir = args.download_dir
+        if not args.basepath is None:
+                if not os.path.isabs(args.get):
+                        Str_GetArg = os.path.join(args.basepath, os.path.basename(args.get))
+                if not os.path.isabs(args.download_dir):
+                        Str_DownloadDir = os.path.join(args.basepath, os.path.basename(args.download_dir))
+                        if not os.path.exists(Str_DownloadDir):
+                                os.mkdir(Str_DownloadDir, 777)
+
+        Int_SocketTimeout = args.socket_timeout
         Str_CacheDir = args.cache_dir
         Bool_DisableMD5Check = args.disable_md5check
         Int_NumOfThreads = args.num_of_threads
@@ -1365,6 +1373,8 @@ def installer( args ):
                                       
             # install opts
             self.Str_InstallArg = args.install
+            if args.basepath is not None and not os.path.isabs(args.install):
+                Str_InstallArg = os.path.join(args.basepath, os.path.basename(args.install))
             self.Bool_TestWindows = args.simulate
             self.Bool_SkipBugReports = args.skip_bug_reports
             self.Bool_Untrusted = args.allow_unauthenticated
@@ -1919,6 +1929,9 @@ def setter(args):
         #log.verbose(str(args))
         # commented to keep setter UI sane for time
         Str_SetArg = args.set
+        if args.basepath is not None and not os.path.isabs(args.set):
+                Str_SetArg = os.path.join(args.basepath, os.path.basename(args.set))
+
         List_SetInstallPackages = args.set_install_packages
         List_SetInstallSrcPackages = args.set_install_src_packages
         Str_SetInstallRelease = args.set_install_release
@@ -2054,6 +2067,7 @@ def main():
         global_options.add_argument("--verbose", dest="verbose", help="Enable verbose messages", action="store_true" )
         global_options.add_argument("--simulate", dest="simulate", help="Just simulate. Very helpful when debugging",
                             action="store_true" )
+        global_options.add_argument("--basepath", dest="basepath", help="Set removeable storage base path")
         
         if argparse.__version__ >= 1.1:
                 parser = argparse.ArgumentParser( prog=app_name, description="Offline APT Package Manager" + ' - ' + version,


### PR DESCRIPTION
These are two commits to implement the simplified interaction discussed in #46:
-  `apt-offline set --basepath /media/usb0`
-  `apt-offline get --basepath /media/usb0`
-  `apt-offline install --basepath /media/usb0`

More detail in the commit messages.
