### PR TITLE
use active git repo in Vcs-* tags

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,8 @@ Build-Depends: debhelper (>= 7), python (>= 2.6.6-3~), dh-python
 Standards-Version: 3.9.3
 X-Python-Version: >= 2.5
 Homepage: http://apt-offline.alioth.debian.org
-Vcs-Git: git://anonscm.debian.org/apt-offline/apt-offline.git
-Vcs-Browser: http://anonscm.debian.org/gitweb/?p=apt-offline/apt-offline.git
+Vcs-Git: https://github.com/rickysarraf/apt-offline.git
+Vcs-Browser: https://github.com/rickysarraf/apt-offline
 
 Package: apt-offline
 Architecture: all


### PR DESCRIPTION
Points the debian things to this git repo, rather than the unmaintained alioth git repo.