### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+apt-offline (1.8.2-2) UNRELEASED; urgency=medium
+
+  * Wrap long lines in changelog entries: 1.8.2-1.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 29 Mar 2020 02:10:30 +0000
+
 apt-offline (1.8.2-1) unstable; urgency=medium
 
   [ Matthias Blümel ]
@@ -24,8 +30,8 @@ apt-offline (1.8.2-1) unstable; urgency=medium
   * Add field Rules-Requires-Root: no
   * Enhance policykit integration
   * Install the apt-offline-gui-pkexec script to usr/bin/
-  * Demote --simulate from global option to sub-option for install and set commands
-    (Closes: #871664)
+  * Demote --simulate from global option to sub-option for install and set
+    commands (Closes: #871664)
   * Do not touch apt system files in simulate mode
   * Also update the manpage about demotion of the simulate option
   * Switch to 3.0 (quilt) source format

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 apt-offline (1.8.2-2) UNRELEASED; urgency=medium
 
   * Wrap long lines in changelog entries: 1.8.2-1.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 29 Mar 2020 02:10:30 +0000
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/rickysarraf/apt-offline/issues
+Bug-Submit: https://github.com/rickysarraf/apt-offline/issues/new
+Repository: https://github.com/rickysarraf/apt-offline.git
+Repository-Browse: https://github.com/rickysarraf/apt-offline


### PR DESCRIPTION
Fix some issues reported by lintian
* Wrap long lines in changelog entries: 1.8.2-1. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/apt-offline/ced1c79c-1c86-4176-b178-95d35e75e3c5.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/ced1c79c-1c86-4176-b178-95d35e75e3c5/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ced1c79c-1c86-4176-b178-95d35e75e3c5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ced1c79c-1c86-4176-b178-95d35e75e3c5/diffoscope)).
