### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+apt-offline (1.8.2-3) UNRELEASED; urgency=medium
+
+  * Update standards version to 4.5.0, no changes needed.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 03:14:10 +0000
+
 apt-offline (1.8.2-2) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Ritesh Raj Sarraf <rrs@debian.org>
 Build-Depends: debhelper-compat (= 12), python3-setuptools, python3-all, dh-python, pyqt5-dev-tools, man2html-base
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/rickysarraf/apt-offline
 Vcs-Git: https://github.com/rickysarraf/apt-offline.git


### PR DESCRIPTION
Fix some issues reported by lintian
* Wrap long lines in changelog entries: 1.8.2-1. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/apt-offline/24c1e4d5-f6b2-4fb0-9758-ddd15f9b5b9f.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/24c1e4d5-f6b2-4fb0-9758-ddd15f9b5b9f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/24c1e4d5-f6b2-4fb0-9758-ddd15f9b5b9f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/24c1e4d5-f6b2-4fb0-9758-ddd15f9b5b9f/diffoscope)).
