### PR TITLE
Complain when there are no valid keyrings instead of missing keyrings

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -624,8 +624,8 @@ class APTVerifySigs(ExecCmd):
                                                 log.verbose("Adding %s to the apt-offline keyring\n" % (eachGPG) )
                                                 eachKeyring = "--keyring %s" % (eachGPG)
                                                 self.opts.extend(eachKeyring.split())
-                                else:
-                                        log.err("Path for keyring is invalid: %s\n" % (eachPath) )
+                        if len(self.opts) == 1:
+                                log.err("No valid keyring paths found in: %s\n" % (", ".join(self.defaultPaths)))
                 else:
                         finalKeyring = "--keyring %s --ignore-time-conflict" % (keyring)
                         self.opts.extend(finalKeyring.split())


### PR DESCRIPTION
Usually it is not a problem if a keyring is missing since
the other keyrings should still be present.