### PR TITLE
Correct usage of the /tmp/ directory

### DIFF
--- a/release_setps
+++ b/release_setps
@@ -5,5 +5,5 @@
 
 
 
-git archive --format=zip --prefix=apt-offline/ v1.6  > /tmp/apt-offline-1.6.zip
-git archive --format=tar.gz --prefix=apt-offline/ v1.6  > /tmp/apt-offline-1.6.tar.gz
+git archive --format=zip --prefix=apt-offline/ v1.6  > apt-offline-1.6.zip
+git archive --format=tar.gz --prefix=apt-offline/ v1.6  > apt-offline-1.6.tar.gz

--- a/tests/apt-offline-tests.sh
+++ b/tests/apt-offline-tests.sh
@@ -2,10 +2,13 @@
 
 DISLIKED_PACKAGES="lxde icewm eclipse"
 RELEASE=`lsb_release -c -s`
-URI="/tmp/set-$PPID.uris"
+DIR="$(mktemp --tmpdir --directory apt-offline-tests-XXXXXXXX)"
+cleanup () { rm --recursive --force "$DIR"; }
+trap cleanup EXIT
+URI="$DIR/set.uris"
 CACHE_DIR="/var/cache/apt/archives"
-DOWNLOAD_DIR="/tmp/apt-offline-tests-$PPID"
-BUNDLE_FILE="/tmp/apt-offline-tests-$PPID.zip"
+DOWNLOAD_DIR="$DIR/download-dir"
+BUNDLE_FILE="$DIR/bundle-file.zip"
 THREADS=5
 APT_OFFLINE="./apt-offline "
 


### PR DESCRIPTION
On multi-user systems it can be dangerous to use /tmp/ without
properly creating temporary files atomically with mktemp.

Suggested-by: check-all-the-things