### PR TITLE
Make the copying of changelog lines less brittle

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -1135,8 +1135,17 @@ def fetcher( args ):
                                 #Seek to beginning
                                 chlogFile.seek(0)
 
+                                if 'Source' in pkgHandle:
+                                    srcname = pkgHandle['Source']
+                                else:
+                                    srcname = pkgHandle.pkgname
+                                if ' ' in srcname:
+                                    srcname = srcname.split(' ', 1)[0]
+                                installedVersion_changelog_line = "%s (%s) " % (srcname, installedVersion)
+
+                                # FIXME: replace this with parsing the changelog using the Python debian module
                                 for eachLine in chlogFile.readlines():
-                                    if installedVersion in eachLine:
+                                    if eachLine.startswith(installedVersion_changelog_line):
                                         break
                                     else:
                                         pkgLogFile.writelines(eachLine)


### PR DESCRIPTION
Stop copying changelog lines when a changelog header containing the exact
version is seen. Until now, random other versions that happened to contain
the installed version did this. Also, any non-header lines that happened to
mention the installed version also did this.

This isn't the most correct fix though, the right way to do this would be
to reimplement the code using proper changelog parsing from the Python
debian module.