### PR TITLE
[#143] Added support for verifying InRelease files

### DIFF
--- a/apt_offline_core/AptOfflineLib.py
+++ b/apt_offline_core/AptOfflineLib.py
@@ -79,6 +79,8 @@ class Checksum:
             data = open( checksumFile, 'rb' )
             if HashType == "sha256":
                 Hash = self.sha256( data )
+            elif HashType == "sha512":
+                Hash = self.sha512( data )
             elif HashType == "md5" or HashType == "md5sum":
                 Hash = self.md5( data )
             else: Hash = None
@@ -94,6 +96,11 @@ class Checksum:
         sha256 = hashlib.sha256()
         sha256.update( data.read() )
         return sha256.hexdigest()
+
+    def sha512( self, data ):
+        sha512 = hashlib.sha512()
+        sha512.update( data.read() )
+        return sha512.hexdigest()
 
     def md5( self, data ):
         md5hash = hashlib.md5()


### PR DESCRIPTION
* Not all repositories still provide Release and Release.gpg files
* Adds directly verification of self-signed InRelease files
* Adds support for sha512 signed packages

See issue at https://github.com/rickysarraf/apt-offline/issues/143

This PR addresses my issues using apt-offline to install from the nvidia-docker repository (at least within my Docker image).  Hopefully it's useful more broadly.  Additional hash types could be supported, but I only needed SHA512.