### PR TITLE
Use proxy settings to configure https proxy

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -971,12 +971,12 @@ def fetcher( args ):
         if Str_ProxyHost:
                 if Str_ProxyPort:
                         log.verbose(Str_ProxyHost + ":" + str(Str_ProxyPort))
-                        proxy_support = urllib.request.ProxyHandler({'http': Str_ProxyHost + ":" + str(Str_ProxyPort) })
+                        proxy_support = urllib.request.ProxyHandler({'http': Str_ProxyHost + ":" + str(Str_ProxyPort), 'https': Str_ProxyHost + ":" + str(Str_ProxyPort)})
                         opener = urllib.request.build_opener(proxy_support)
                         urllib.request.install_opener(opener)
                         log.verbose("Proxy successfully set up with Host %s and port %s\n" % (Str_ProxyHost, str(Str_ProxyPort)))
                 else:
-                        proxy_support = urllib.request.ProxyHandler({'http': Str_ProxyHost})
+                        proxy_support = urllib.request.ProxyHandler({'http': Str_ProxyHost, 'https': Str_ProxyHost})
                         opener = urllib.request.build_opener(proxy_support)
                         urllib.request.install_opener(opener)
                         log.verbose("Proxy successfully set up with Host %s and default port\n" % (Str_ProxyHost) )


### PR DESCRIPTION
I used the existing proxy settings to configure a https proxy.
This allows the usage of sources like https://download.docker.com/linux/ubuntu despite using a proxy.