### PR TITLE
Error out if we cannot initialize the APT lock

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -693,7 +693,7 @@ class LockAPT:
                 except Exception:
                         log.verbose(traceback.format_exc())
                         log.err("Couldn't open lockfile\n")
-                        return False
+                        sys.exit(1)
 
         def lockLists(self):
                 try:


### PR DESCRIPTION
If we do not acquire an APT lock, we should immediately bail out because
we have no insight into what might be going wrong on that machine

Thanks: Matthew Maslak