### PR TITLE
Fixes issue 199 by ignoring items/lines that are completely invalid when parsing a signature file

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -1250,7 +1250,15 @@ def fetcher( args ):
                                 # Interim fix for Debian bug #664654
                                 # FIXME is this needed still with explicit install handling?
                                 # Will cause double syncing of files on install
-                                (ItemURL, ItemFile, ItemSize, ItemChecksum) = stripper(item)
+                                try :
+                                    (ItemURL, ItemFile, ItemSize, ItemChecksum) = stripper(item)
+                                except :
+                                    # There is an issue with this line so just ignore it.
+                                    # Note that putting the split in a try block fixes issue 199:
+                                    # https://github.com/rickysarraf/apt-offline/issues/199
+                                    log.verbose("Ignoring unusable item: %s\n" % item)
+                                    continue
+                                
                                 if not ItemURL.startswith(('http', 'https', 'ftp')):
                                         log.verbose("This is a broken url: %s\n" % (ItemURL))
                                         continue


### PR DESCRIPTION
Fixes [issue 199](https://github.com/rickysarraf/apt-offline/issues/199).

Since the generation of the signature file is done by directly writing the output of the apt backend command, it was easier to fix this when parsing the signature file by putting the line splitting in a `try` block and simple ignoring that line/item if that fails.

In my opinion this isn't even an issue that we should have to fix in `apt-offline`. It _should_ be the case that `apt` and `apt-get` do not output this advertisement when you enable the highest quiet level like `apt-offline` does. If this _is_ fixed in those tools later, this `apt-offline` fix will just have no effect but will not cause any problems. This fix should also protect against any future odd lines that they decide to have `apt` or `apt-get` print out even in quiet mode.