### PR TITLE
check for checksum and handle appropriately

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -864,7 +864,11 @@ def stripper(item):
         url = SplitItem[0].strip("'").strip()
         localFile = SplitItem[1].strip("'").strip()
         size = SplitItem[2].strip("'").strip()
-        checksum = SplitItem[3].strip("'").strip()
+        try:
+            checksum = SplitItem[3].strip("'").strip()
+        except IndexError:
+            checksum = None
+            log.verbose("line %s is missing checksum entry" % (item))
         log.verbose("Items after split is: %s\n" % (SplitItem))
 
         # Convert size to integer


### PR DESCRIPTION
Note that checksum is not always available in the signature file. For example, for the `--update` operation, there's no checksum in the signature. Instead, that is handled separately via GPG Repository Singing.

The checksums are only present for the build package files, like the .deb files. That's because in Debian, we only sign the repository metadata and list all checksums and other important bits, as part of that metadata

Closes: https://github.com/rickysarraf/apt-offline/issues/216
Thanks: Dan Whitman (Github:kyp44)