### PR TITLE
Retry when server reports 429 Too Many Requests occurs

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -888,9 +888,10 @@ def errfunc(errno, errormsg, filename):
     be well accessible.
     This function does the job of behaving accordingly
     as per the error codes.'''
-    retriable_error_codes = [-3, 13, 404, 403, 401, 10060, 104, 101010]
+    retriable_error_codes = [-3, 13, 404, 403, 401, 429, 10060, 104, 101010]
     # 104, 'Connection reset by peer'
     # 504 is for gateway timeout
+    # 429 Too Many Requests
     # 404 is for URL error. Page not found.
     # 401 is for Restricted pages
     # 10060 is for Operation Time out. There can be multiple reasons for this timeout


### PR DESCRIPTION
An HTTP/1.1 429 Too Many Requests occurs when:

* there are too many requests
* server is overloaded

The server may respond back with a `Retry-after` field with the value in seconds. For now, we'll just retry immediately. A potential enhancement could be to honor `Retry-after` but, thinking of it, it doesn't fit the bill for `apt-offline` because we want the download operation to conclude immediately rather than wait for `Retry-after` seconds.

Thanks: Zoltan Kelemen (Github: misterzed88)
Closes: https://github.com/rickysarraf/apt-offline/issues/213