### PR TITLE
Feat/print uris

### DIFF
--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -1029,7 +1029,7 @@ def stripper(item):
         checksum = SplitItem[3].strip("'").strip()
     except IndexError:
         checksum = None
-        log.verbose("line %s is missing checksum entry" % (item))
+        log.verbose("line %s is missing checksum entry\n" % (item))
     log.verbose("Items after split is: %s\n" % (SplitItem))
 
     # Convert size to integer

--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -1109,6 +1109,7 @@ def fetcher(args):
     Str_HttpBasicAuth = args.http_basicauth
     Bool_DisableCertCheck = args.disable_cert_check
     Bool_BugReports = args.deb_bugs
+    Bool_Simulate = args.get_simulate
     global guiTerminateSignal
 
     if Int_SocketTimeout:
@@ -1616,7 +1617,9 @@ def fetcher(args):
                             LINE_OVERWRITE_FULL,
                         )
                     )
-                    if FetcherInstance.download_from_web(url, pkgFile, Str_DownloadDir):
+                    if Bool_Simulate:
+                        log.uris(url, pkgFile)
+                    elif FetcherInstance.download_from_web(url, pkgFile, Str_DownloadDir):
                         log.success("%s done %s\n" %
                                     (PackageName, LINE_OVERWRITE_FULL))
                         FetcherInstance.writeData(pkgFile)
@@ -1639,7 +1642,9 @@ def fetcher(args):
                         LINE_OVERWRITE_FULL,
                     )
                 )
-                if FetcherInstance.download_from_web(url, pkgFile, Str_DownloadDir):
+                if Bool_Simulate:
+                    log.uris(url, pkgFile)
+                elif FetcherInstance.download_from_web(url, pkgFile, Str_DownloadDir):
                     log.success("%s done %s\n" %
                                 (PackageName, LINE_OVERWRITE_FULL))
                     FetcherInstance.writeData(pkgFile)
@@ -1656,7 +1661,9 @@ def fetcher(args):
         else:
 
             def DownloadPackages(PackageName, PackageFile):
-                if FetcherInstance.download_from_web(
+                if Bool_Simulate:
+                    log.uris(PackageName, PackageFile)
+                elif FetcherInstance.download_from_web(
                     PackageName, PackageFile, Str_DownloadDir
                 ):
                     log.success("%s done %s\n" %
@@ -1823,7 +1830,9 @@ def fetcher(args):
                 log.err("\nInterrupted by user. Exiting!\n")
                 sys.exit(0)
 
-    if args.bundle_file:
+    if Bool_Simulate:
+        log.msg("\nNo data was downloaded, only printed URIs\n")
+    elif args.bundle_file:
         log.msg("\nDownloaded data to %s\n" % (Str_BundleFile))
     else:
         log.msg("\nDownloaded data to %s\n" % (Str_DownloadDir))
@@ -3086,6 +3095,13 @@ def main():
         "--bug-reports",
         dest="deb_bugs",
         help="Fetch bug reports from the BTS",
+        action="store_true",
+    )
+
+    parser_get.add_argument(
+        "--simulate",
+        dest="get_simulate",
+        help="Print URIs and filenames instead of downloading",
         action="store_true",
     )
 

--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -1618,7 +1618,7 @@ def fetcher(args):
                         )
                     )
                     if Bool_Simulate:
-                        log.uris(url, pkgFile)
+                        log.uris(url, os.path.join(Str_DownloadDir, pkgFile))
                     elif FetcherInstance.download_from_web(url, pkgFile, Str_DownloadDir):
                         log.success("%s done %s\n" %
                                     (PackageName, LINE_OVERWRITE_FULL))
@@ -1643,7 +1643,7 @@ def fetcher(args):
                     )
                 )
                 if Bool_Simulate:
-                    log.uris(url, pkgFile)
+                    log.uris(url, os.path.join(Str_DownloadDir, pkgFile))
                 elif FetcherInstance.download_from_web(url, pkgFile, Str_DownloadDir):
                     log.success("%s done %s\n" %
                                 (PackageName, LINE_OVERWRITE_FULL))
@@ -1662,7 +1662,7 @@ def fetcher(args):
 
             def DownloadPackages(PackageName, PackageFile):
                 if Bool_Simulate:
-                    log.uris(PackageName, PackageFile)
+                    log.uris(PackageName, os.path.join(Str_DownloadDir, PackageFile))
                 elif FetcherInstance.download_from_web(
                     PackageName, PackageFile, Str_DownloadDir
                 ):

--- a/apt_offline_core/AptOfflineCoreLib.py
+++ b/apt_offline_core/AptOfflineCoreLib.py
@@ -1030,7 +1030,7 @@ def stripper(item):
     except IndexError:
         checksum = None
         log.verbose("line %s is missing checksum entry\n" % (item))
-    log.verbose("Items after split is: %s\n" % (SplitItem))
+    log.verbose("Items after split are: %s\n" % (SplitItem))
 
     # Convert size to integer
     size = int(size) if size.isdecimal() else 0

--- a/apt_offline_core/AptOfflineLib.py
+++ b/apt_offline_core/AptOfflineLib.py
@@ -280,7 +280,7 @@ class Log:
 
     # For the rest, we need to check the options also
     def verbose(self, msg):
-        """Print verbose messages. If locking is available use them."""
+        """Print verbose messages. If locking is available, use it."""
         if self.lock:
             self.DispLock.acquire()
 

--- a/apt_offline_core/AptOfflineLib.py
+++ b/apt_offline_core/AptOfflineLib.py
@@ -293,6 +293,10 @@ class Log:
         if self.lock:
             self.DispLock.release()
 
+    def uris(self, url, localFile):
+        """Print URIs as they are requested."""
+        print("URIs: %s %s" % (url, localFile))
+
     def calcSize(self, size):
         """Takes number of kB and returns a string
         of proper size. Like if > 1024, return a megabyte"""


### PR DESCRIPTION
add `--simulate` command line option to `apt-offline get` to print URIs and corresponding local filename and skip downloading files.

Closes https://github.com/rickysarraf/apt-offline/issues/247

Also fixing minor typos.